### PR TITLE
Change to the way services are called

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -25,6 +25,7 @@
 #undef ENABLE_USB
 #endif
 
+#include "status_led.h"
 #include "console.h"
 #include "cli.h"
 #include "debug-commands.h"
@@ -486,6 +487,7 @@ int main(void)
 #ifdef ENABLE_TELEMETRY_SERVICE
     init_telemetry_service(&rn2483_g, &altimeter_g, TELEMETRY_RATE);
 #endif
+    status_set(STATUS_OK);
     
     
     // Start Watchdog Timer
@@ -518,13 +520,6 @@ static void main_loop (void)
     if ((millis - lastLed_g) >= period) {
         lastLed_g = millis;
         gpio_toggle_output(DEBUG0_LED_PIN);
-    }
-    
-    static uint32_t last_stat;
-    if (((millis - last_stat) >= STAT_PERIOD)) {
-        last_stat = millis;
-        gpio_toggle_output(STAT_R_LED_PIN);
-        gpio_toggle_output(STAT_G_LED_PIN);
     }
     
 #ifdef ENABLE_CONSOLE

--- a/src/service_watchdog.c
+++ b/src/service_watchdog.c
@@ -1,0 +1,51 @@
+/**
+ * @file service_watchdog.c
+ * @desc Manage services and watch for errors
+ * @author Quinn Parrott
+ * @date 2020-02-01
+ * Last Author:
+ * Last Edited On:
+ */
+
+#include "service_watchdog.h"
+
+#include "config.h"
+#include "wdt.h"
+
+
+static uint32_t lastLed_g;
+
+void service_loop(service_t *services, uint8_t services_size) {
+
+    uint8_t service_index = 0;
+
+    // Start Watchdog Timer
+    init_wdt(GCLK_CLKCTRL_GEN_GCLK7, 14, 0);
+
+    // Main Loop
+    for (;;) {
+
+        // Pat the watchdog
+        wdt_pat();
+
+        // TODO: Move heartbeat into it's own service
+        static uint32_t period = 1000;
+
+        if ((millis - lastLed_g) >= period) {
+            lastLed_g = millis;
+            gpio_toggle_output(DEBUG0_LED_PIN);
+        }
+
+        service_t current_service = services[service_index];
+
+        current_service.call(current_service.storage);
+
+        // Increment to the next service
+        service_index = (service_index + 1) % services_size;
+
+        // Sleep if sleep is not inhibited
+        if (!inhibit_sleep_g) {
+            __WFI();
+        }
+    }
+}

--- a/src/service_watchdog.h
+++ b/src/service_watchdog.h
@@ -1,0 +1,30 @@
+/**
+ * @file service_watchdog.h
+ * @desc Manage services and watch for errors
+ * @author Quinn Parrott
+ * @date 2020-02-01
+ * Last Author:
+ * Last Edited On:
+ */
+
+#ifndef service_watchdog_h
+#define service_watchdog_h
+
+#include "global.h"
+
+
+typedef struct service_t {
+    void* storage;
+    void* (*call)(void*);
+    //uint8_t (*status_callback)(void*);
+} service_t;
+
+/**
+ * Entrypoint for the loop that calls all service.
+ *
+ * @param services An array containing the definitions of all the services.
+ * @param services_size The size of services.
+ */
+extern void service_loop(service_t *services, uint8_t services_size);
+
+#endif /* service_watchdog_h */

--- a/src/status_led.c
+++ b/src/status_led.c
@@ -1,0 +1,43 @@
+/**
+ * @file status_led.c
+ * @desc Control the status led
+ * @author Quinn Parrott
+ * @date 2020-02-01
+ * Last Author:
+ * Last Edited On:
+ */
+
+#include "status_led.h"
+
+#include "config.h"
+#include "gpio.h"
+
+
+void status_set(uint8_t error) {
+
+    #ifdef pins_rev_a_h
+    // Revision A of the board is not full RGB. It only has
+    // a bi-directional red green LED.
+    if (error != STATUS_OK) {
+        gpio_set_output(STAT_G_LED_PIN, 0);
+        gpio_set_output(STAT_R_LED_PIN, 1);
+    } else {
+        gpio_set_output(STAT_R_LED_PIN, 0);
+        gpio_set_output(STAT_G_LED_PIN, 1);
+    }
+    #endif
+
+    #ifdef pins_rev_b_h
+    // In status_led.h the LED
+    gpio_set_output(STAT_R_LED_PIN, error & 1);
+    gpio_set_output(STAT_G_LED_PIN, (error >> 1) & 1);
+    gpio_set_output(STAT_B_LED_PIN, (error >> 2) & 1);
+    #endif
+
+    if (error != STATUS_OK) {
+        gpio_set_output(DEBUG1_LED_PIN, 1);
+    } else {
+        gpio_set_output(DEBUG1_LED_PIN, 0);
+    }
+
+}

--- a/src/status_led.h
+++ b/src/status_led.h
@@ -1,0 +1,41 @@
+/**
+ * @file status_led.h
+ * @desc Control the status led
+ * @author Quinn Parrott
+ * @date 2020-02-01
+ * Last Author:
+ * Last Edited On:
+ */
+
+#ifndef status_led_h
+#define status_led_h
+
+#include "global.h"
+
+
+#define LED_OFF 0
+#define LED_RED 1
+#define LED_GREEN 2
+#define LED_BLUE 4
+#define LED_YELLOW (LED_RED | LED_GREEN)
+#define LED_CYAN (LED_GREEN | LED_BLUE)
+#define LED_MAGENTA (LED_BLUE | LED_RED)
+#define LED_WHITE (LED_RED | LED_GREEN | LED_BLUE)
+
+// Something when wrong at boot
+#define STATUS_STARTUP_ERROR LED_OFF
+// Everything is running fine
+#define STATUS_OK LED_GREEN
+// General error
+#define STATUS_ERROR LED_RED
+
+
+/**
+ *  Set the error LED
+ *
+ *  @param error One of the constants defined in status_led.h
+ *  @return 0 if successful, non-zero otherwise
+ */
+extern void status_set(uint8_t error);
+
+#endif /* status_led_h */


### PR DESCRIPTION
## General Information
These 2 commits add both a status LED interface and change the way services are called. This addresses issue #26.

## Status LED
The status LED interface is very simple, the header defines a couple statuses that can be represented by the LED. The status are called as such:
```c
status_set(STATUS_OK);
status_set(STATUS_ERROR);
```
This works on both rev A and B. More error codes are possible to represent all the colors available to a RGB LED.
## Services calls
Services are now registered in array called 'SERVICES' as service_t instead of being put into 'main_loop'.
This is the old way:
_main.c_
```c
static void main_loop (void) {

#ifdef ENABLE_CONSOLE
    console_service(&console_g);
#endif
    [...]
}
```
vs the new way:
_main.c_
```c
service_t SERVICES[] = {
#ifdef ENABLE_CONSOLE
    {&console_g, (void*) console_service},
#endif
    [...]
};
```
This should allow more fine grain control over the working of each module in the future, for example a function that returns the modules status then decides the appropriate action to take (either system restart, or just skipping it). This would be accomplished by putting a callback into 'SERVICE' then calling it in 'service_loop'.

## Final notes
The wiki will need to be changed to reflect the new service interface.