### PR TITLE
Fix SAME54 SysTick reload value

### DIFF
--- a/src/targets/sam/same54/target.c
+++ b/src/targets/sam/same54/target.c
@@ -360,7 +360,7 @@ void init_target(void)
 
     // Enable SysTick for an interrupt every 10 milliseconds, this is just to
     // make sure that we wake the main loop occasionally, not for time keeping
-    SysTick_Config(12000);
+    SysTick_Config(F_CPU / 100);
     // Give SysTick interrupt lowest priority
     NVIC_SetPriority(SysTick_IRQn, 7);
 }


### PR DESCRIPTION
I stole a bit of code from this repo today, and discovered that my math for the SysTick setting for the SAME54 was very wrong.

Rather than an interrupt every 10 milliseconds to ensure that the main loop gets run regularly, the SysTick is being configured to generate an interrupt every 100 microseconds. This will prevent the system from sleeping for any meaningful amount of time.

This change corrects the math so that the correct SysTick reload value is used. Note that I no longer have a whole system worth of hardware, so I have not been able to thoroughly test this on a full system. This is a small risk that this change will uncover problems in modules that could be (erroneously) relying on the main loop running more often than every 10 milliseconds.